### PR TITLE
Minor fix to _ handling

### DIFF
--- a/src/convert.test.ts
+++ b/src/convert.test.ts
@@ -4,10 +4,10 @@ import { convert, verbose } from "./convert.ts"
 verbose()
 
 // https://github.com/jadujoel/markdown-to-jira/issues/1
-test.it('should render bold correctly', () => {
+test.it('should render _ correctly', () => {
   test.expect(convert("__bold__").trim()).toEqual("*bold*")
-  test.expect(convert("\_\_bold\_\_").trim()).toEqual("\_\_bold\_\_")
-  test.expect(convert("my__bold__key my__bold__key").trim()).toEqual("my\_\_bold\_\_key my\_\_bold\_\_key")
-  test.expect(convert("my\_bold\_\_key my\_bold\_\_key").trim()).toEqual("my\_bold\_\_key my\_bold\_\_key")
-  test.expect(convert("some_thing").trim()).toEqual("some\_thing")
+  test.expect(convert(String.raw`\_\_bold\_\_`).trim()).toEqual(String.raw`\_\_bold\_\_`)
+  test.expect(convert("my__key my__key").trim()).toEqual(String.raw`my\_\_key my\_\_key`)
+  test.expect(convert("`my__key my__key`").trim()).toEqual(String.raw`{{my\_\_key my\_\_key}}`)
+  test.expect(convert("```\nmy__key my__key\n```").trim()).toEqual("{code:language=|borderStyle=solid|theme=RDark|linenumbers=true|collapse=false}\nmy__key my__key\n{code}")
 })

--- a/src/convert.test.ts
+++ b/src/convert.test.ts
@@ -6,6 +6,8 @@ verbose()
 // https://github.com/jadujoel/markdown-to-jira/issues/1
 test.it('should render bold correctly', () => {
   test.expect(convert("__bold__").trim()).toEqual("*bold*")
-  test.expect(convert("my__bold__key my__bold__key").trim()).toEqual("my__bold__key my__bold__key")
-  test.expect(convert("my_bold__key my_bold__key").trim()).toEqual("my_bold__key my_bold__key")
+  test.expect(convert("\_\_bold\_\_").trim()).toEqual("\_\_bold\_\_")
+  test.expect(convert("my__bold__key my__bold__key").trim()).toEqual("my\_\_bold\_\_key my\_\_bold\_\_key")
+  test.expect(convert("my\_bold\_\_key my\_bold\_\_key").trim()).toEqual("my\_bold\_\_key my\_bold\_\_key")
+  test.expect(convert("some_thing").trim()).toEqual("some\_thing")
 })


### PR DESCRIPTION
**Original Issue:** 
Markdown: one__two three__four
Jira: one_<em>two three</em>_four

**Goal of PR**: 
Markdown: one__two three__four
Jira: one__two three__four

**Solution**: 
After `marked` runs:
Make  __ -> \\\_\\\_  (if not in a code block)

Note:
Since \_\_bold\_\_ -> \*bold\* after `marked` runs we don't have to worry about ruining any formatting

<details>
<summary><strong>Screenshots</strong></summary>
<img width="891" alt="Screenshot 2025-05-13 at 1 36 45 AM" src="https://github.com/user-attachments/assets/58de2888-8883-43a1-8a6c-202d609770d4" />

<img width="614" alt="Screenshot 2025-05-13 at 1 40 24 AM" src="https://github.com/user-attachments/assets/62384902-d6a4-41cb-a50b-7f45d1fd553b" />

<img width="595" alt="Screenshot 2025-05-13 at 1 40 40 AM" src="https://github.com/user-attachments/assets/f6590538-a05e-460d-8a18-e3437b357c28" />
</details>


**Warning**
I didn't have tests for the Code Block Commenting logic. Not sure what the fix is for, so I wasn't able to test it.
I am pretty sure my refactor should be the same, but without testing, you never know. It may be good to add tests for that logic! (And possibly some other basic logic)

**In Depth Code Notes:**
Split `fixCommentedCodeBlocks` into two functions, a generic function `processCodeBlockLines` and a specific function with the original name that utilizes the new generic function.

The new generic function `processCodeBlockLines` allows applying transformations based on whether the line is in a code block or not.

This split was done to utilize `processCodeBlockLines` for __ -> \_\_ transformation function.

Fix logical bug in `fixCommentedCodeBlocks`/`processCodeBlockLines` where:
```
if (line.includes('{code')) {
   // ... 
} else if (line.includes('{code}'){
   // BUG: Never runs, since the above if would always be true.
}
```

Modify tests to make sure _'s are handled properly

Minor reformat to "convert" function to easily understand function order.